### PR TITLE
Fix folder link in USE/GET in static assets

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -22,11 +22,11 @@ app.use(express.json());
 
 // Serve up static assets
 if (process.env.NODE_ENV === "production") {
-  app.use(express.static(path.join(__dirname, "../client/")));
+  app.use(express.static(path.join(__dirname, "../client/build")));
 }
 
 app.get("/*", (req, res) => {
-  res.sendFile(path.join(__dirname, "../client/"));
+  res.sendFile(path.join(__dirname, "../client/build/index.html"));
 });
 
   //New apollo server


### PR DESCRIPTION
Attempt to fix Heroku build issue - SWITCH

// Serve up static assets
if (process.env.NODE_ENV === "production") {
  app.use(express.static(path.join(__dirname, "../client")));
}
TO

if (process.env.NODE_ENV === "production") {
  app.use(express.static(path.join(__dirname, "../client/build")));
}

AND 

app.get("/*", (req, res) => {
  res.sendFile(path.join(__dirname, "../client"));
});

TO

app.get("/*", (req, res) => {
  res.sendFile(path.join(__dirname, "../client/build/index.html"));
});